### PR TITLE
Add sorbet and typing info to work with Tapioca

### DIFF
--- a/lib/rails_values.rb
+++ b/lib/rails_values.rb
@@ -18,7 +18,6 @@ require_relative 'rails_values/html_content'
 require_relative 'rails_values/country'
 require_relative 'rails_values/industry'
 require_relative 'rails_values/industry_list'
-require_relative 'rails_values/currency_casting'
 
 require_relative 'rails_values/simple_string_converter'
 require_relative 'rails_values/simple_json_converter'

--- a/lib/rails_values/country_active_model_converter.rb
+++ b/lib/rails_values/country_active_model_converter.rb
@@ -1,0 +1,18 @@
+require 'sorbet-runtime'
+require 'rails_values/country'
+
+module RailsValues
+  class CountryActiveModelConverter < ActiveModel::Type::Value
+    extend T::Sig
+
+    sig { params(value: T.untyped).returns(T.any(Country, BlankCountry, ExceptionalValue)) }
+    def cast(value)
+      Country.cast(value)
+    end
+
+    sig { params(value: T.untyped).returns(String) }
+    def serialize(value)
+      value.to_s
+    end
+  end
+end

--- a/lib/rails_values/currency_casting.rb
+++ b/lib/rails_values/currency_casting.rb
@@ -1,11 +1,15 @@
+require 'sorbet-runtime'
 require 'money'
 
 module RailsValues
   class CurrencyCasting < ActiveModel::Type::Value
+    extend T::Sig
+
     def self.cast(value)
       new.cast(value)
     end
 
+    sig { params(value: T.untyped).returns(T.nilable(Money::Currency)) }
     def cast(value)
       if value.is_a? Money::Currency
         value
@@ -14,6 +18,7 @@ module RailsValues
       end
     end
 
+    sig { params(value: T.untyped).returns(T.nilable(String)) }
     def serialize(value)
       if value.is_a? Money::Currency
         value.iso_code

--- a/lib/rails_values/email_address_active_model_converter.rb
+++ b/lib/rails_values/email_address_active_model_converter.rb
@@ -1,0 +1,18 @@
+require 'sorbet-runtime'
+require 'rails_values/email_address'
+
+module RailsValues
+  class EmailAddressActiveModelConverter < ActiveModel::Type::Value
+    extend T::Sig
+
+    sig { params(value: T.untyped).returns(T.any(EmailAddress, ExceptionalValue)) }
+    def cast(value)
+      EmailAddress.cast(value)
+    end
+
+    sig { params(value: T.untyped).returns(String) }
+    def serialize(value)
+      value.to_s
+    end
+  end
+end

--- a/lib/rails_values/http_url.rb
+++ b/lib/rails_values/http_url.rb
@@ -1,4 +1,5 @@
 require_relative 'whole_value_concern'
+require_relative 'exceptional_value'
 
 module RailsValues
   class HttpUrl

--- a/lib/rails_values/http_url_active_model_converter.rb
+++ b/lib/rails_values/http_url_active_model_converter.rb
@@ -1,0 +1,18 @@
+require 'sorbet-runtime'
+require 'rails_values/http_url'
+
+module RailsValues
+  class HttpUrlActiveModelConverter < ActiveModel::Type::Value
+    extend T::Sig
+
+    sig { params(value: T.untyped).returns(T.any(HttpUrl, ExceptionalValue)) }
+    def cast(value)
+      HttpUrl.cast(value)
+    end
+
+    sig { params(value: T.untyped).returns(String) }
+    def serialize(value)
+      value.to_s
+    end
+  end
+end

--- a/lib/rails_values/public_domain_suffix_active_model_converter.rb
+++ b/lib/rails_values/public_domain_suffix_active_model_converter.rb
@@ -1,0 +1,18 @@
+require 'sorbet-runtime'
+require 'rails_values/public_domain_suffix'
+
+module RailsValues
+  class PublicDomainSuffixActiveModelConverter < ActiveModel::Type::Value
+    extend T::Sig
+
+    sig { params(value: T.untyped).returns(T.any(PublicDomainSuffix, PublicDomainSuffixBlank, ExceptionalValue)) }
+    def cast(value)
+      PublicDomainSuffix.cast(value)
+    end
+
+    sig { params(value: T.untyped).returns(String) }
+    def serialize(value)
+      value.to_s
+    end
+  end
+end

--- a/lib/rails_values/railtie.rb
+++ b/lib/rails_values/railtie.rb
@@ -1,34 +1,28 @@
-require_relative 'email_address_serializer'
-require_relative 'http_url_serializer'
-require_relative 'public_domain_suffix_serializer'
-
 ValueValidator = RailsValues::ValueValidator
 
 module RailsValues
   class Railtie < ::Rails::Railtie
     initializer 'rails_values_railtie.configure_rails_initialization' do
+      require_relative 'email_address_serializer'
       Rails.application.config.active_job.custom_serializers << EmailAddressSerializer
+
+      require_relative 'http_url_serializer'
       Rails.application.config.active_job.custom_serializers << HttpUrlSerializer
+
+      require_relative 'public_domain_suffix_serializer'
       Rails.application.config.active_job.custom_serializers << PublicDomainSuffixSerializer
 
-      ActiveRecord::Type.register(:rv_country) do
-        SimpleStringConverter.new(Country)
-      end
-      ActiveRecord::Type.register(:rv_email_address) do
-        SimpleStringConverter.new(EmailAddress)
-      end
-      ActiveRecord::Type.register(:rv_subdomain) do
-        SimpleStringConverter.new(Subdomain)
-      end
-      ActiveRecord::Type.register(:rv_public_domain_suffix) do
-        SimpleStringConverter.new(PublicDomainSuffix)
-      end
-      ActiveRecord::Type.register(:rv_http_url) do
-        SimpleStringConverter.new(HttpUrl)
-      end
-      ActiveRecord::Type.register(:rv_currency) do
-        SimpleStringConverter.new(CurrencyCasting)
-      end
+      ActiveRecord::Type.register(:rv_subdomain) { SimpleStringConverter.new(Subdomain) }
+      require_relative 'country_active_model_converter'
+      ActiveRecord::Type.register(:rv_country) { CountryActiveModelConverter }
+      require_relative 'email_address_active_model_converter'
+      ActiveRecord::Type.register(:rv_email_address) { EmailAddressActiveModelConverter }
+      require_relative 'public_domain_suffix_active_model_converter'
+      ActiveRecord::Type.register(:rv_public_domain_suffix) { PublicDomainSuffixActiveModelConverter }
+      require_relative 'http_url_active_model_converter'
+      ActiveRecord::Type.register(:rv_http_url) { HttpUrlActiveModelConverter }
+      require_relative 'currency_casting'
+      ActiveRecord::Type.register(:rv_currency) { CurrencyCasting }
     end
   end
 end

--- a/lib/rails_values/railtie.rb
+++ b/lib/rails_values/railtie.rb
@@ -14,15 +14,15 @@ module RailsValues
 
       ActiveRecord::Type.register(:rv_subdomain) { SimpleStringConverter.new(Subdomain) }
       require_relative 'country_active_model_converter'
-      ActiveRecord::Type.register(:rv_country) { CountryActiveModelConverter }
+      ActiveRecord::Type.register(:rv_country) { CountryActiveModelConverter.new }
       require_relative 'email_address_active_model_converter'
-      ActiveRecord::Type.register(:rv_email_address) { EmailAddressActiveModelConverter }
+      ActiveRecord::Type.register(:rv_email_address) { EmailAddressActiveModelConverter.new }
       require_relative 'public_domain_suffix_active_model_converter'
-      ActiveRecord::Type.register(:rv_public_domain_suffix) { PublicDomainSuffixActiveModelConverter }
+      ActiveRecord::Type.register(:rv_public_domain_suffix) { PublicDomainSuffixActiveModelConverter.new }
       require_relative 'http_url_active_model_converter'
-      ActiveRecord::Type.register(:rv_http_url) { HttpUrlActiveModelConverter }
+      ActiveRecord::Type.register(:rv_http_url) { HttpUrlActiveModelConverter.new }
       require_relative 'currency_casting'
-      ActiveRecord::Type.register(:rv_currency) { CurrencyCasting }
+      ActiveRecord::Type.register(:rv_currency) { CurrencyCasting.new }
     end
   end
 end

--- a/rails_values.gemspec
+++ b/rails_values.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rails_values'
-  spec.version       = '1.0.2'
+  spec.version       = '1.1.0'
   spec.authors       = ['grant']
   spec.email         = ['grant@nexl.io']
 
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json', '>= 1.0.0', '< 2.0'
   spec.add_dependency 'net-smtp', '>= 0.3.0', '< 2.0'
   spec.add_dependency 'public_suffix', '>= 5.0.0', '< 6.0'
+  spec.add_dependency 'sorbet-runtime', '>= 0.5.0', '< 2.0'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/rails_values/country_active_model_converter_spec.rb
+++ b/spec/rails_values/country_active_model_converter_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_values/country_active_model_converter'
+
+module RailsValues
+  RSpec.describe CountryActiveModelConverter do
+    subject { described_class.new }
+
+    it 'can cast and serialize regular value' do
+      value = Country.cast('ZA')
+      expect(value).to be_regular # confirm we have a regular
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+
+    it 'can cast and serialize exceptional value' do
+      value = Country.cast('{}')
+      expect(value).to be_exceptional # confirm we have a exceptional
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+
+    it 'can cast and serialize blank value' do
+      value = Country.cast('')
+      expect(value).to be_blank # confirm we have a blank
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+  end
+end

--- a/spec/rails_values/email_address_active_model_converter_spec.rb
+++ b/spec/rails_values/email_address_active_model_converter_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_values/email_address_active_model_converter'
+
+module RailsValues
+  RSpec.describe EmailAddressActiveModelConverter do
+    subject { described_class.new }
+
+    it 'can cast and serialize regular value' do
+      value = EmailAddress.cast('my.mail@gmail.com')
+      expect(value).to be_regular # confirm we have a regular
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+
+    it 'can cast and serialize exceptional value' do
+      value = EmailAddress.cast('my.mail@localhost')
+      expect(value).to be_exceptional # confirm we have a exceptional
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+
+    it 'can cast and serialize blank value' do
+      value = EmailAddress.cast('')
+      expect(value).to be_blank # confirm we have a blank
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+  end
+end

--- a/spec/rails_values/http_url_active_model_converter_spec.rb
+++ b/spec/rails_values/http_url_active_model_converter_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_values/http_url_active_model_converter'
+
+module RailsValues
+  RSpec.describe HttpUrlActiveModelConverter do
+    subject { described_class.new }
+
+    it 'can cast and serialize regular value' do
+      value = HttpUrl.cast('http://localhost')
+      expect(value).to be_regular # confirm we have a regular
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+
+    it 'can cast and serialize exceptional value' do
+      value = HttpUrl.cast('{}')
+      expect(value).to be_exceptional # confirm we have a exceptional
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+
+    it 'can cast and serialize blank value' do
+      value = HttpUrl.cast('')
+      expect(value).to be_blank # confirm we have a blank
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+  end
+end

--- a/spec/rails_values/public_domain_suffix_active_model_converter_spec.rb
+++ b/spec/rails_values/public_domain_suffix_active_model_converter_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_values/public_domain_suffix_active_model_converter'
+
+module RailsValues
+  RSpec.describe PublicDomainSuffixActiveModelConverter do
+    subject { described_class.new }
+
+    it 'can cast and serialize regular value' do
+      value = PublicDomainSuffix.cast('gmail.com')
+      expect(value).to be_regular # confirm we have a regular
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+
+    it 'can cast and serialize exceptional value' do
+      value = PublicDomainSuffix.cast('{}')
+      expect(value).to be_exceptional # confirm we have a exceptional
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+
+    it 'can cast and serialize blank value' do
+      value = PublicDomainSuffix.cast('')
+      expect(value).to be_blank # confirm we have a blank
+
+      value_serialized = subject.serialize(value)
+      value_casted = subject.cast(value_serialized)
+
+      expect(value_serialized).to be_a(String)
+      expect(value_casted).to eq(value)
+    end
+  end
+end


### PR DESCRIPTION
Tapioca looks at the typing infomation of the ActiveModel::Type::Value subclass when using rails attributes, so by using specific converters for each rails value type and setting return types this will get Tapioca dsl to generate the typing information correctly instead of T.untyped

Figure this out by reading through the dsl compiler for active record columns : https://github.com/Shopify/tapioca/blob/main/lib/tapioca/dsl/compilers/active_record_columns.rb