### PR TITLE
Ignore state public suffixes e.g. qld.gov.au

### DIFF
--- a/lib/rails_values/nexl_public_suffix_list.rb
+++ b/lib/rails_values/nexl_public_suffix_list.rb
@@ -1,0 +1,4 @@
+NEXL_IGNORED_PUBLIC_SUFFIX = %w[qld.gov.au sa.gov.au tas.gov.au vic.gov.au wa.gov.au].freeze
+
+NEXL_LIST = PublicSuffix::List.new
+PublicSuffix::List.default.each { |r| NEXL_LIST.add(r) if !NEXL_IGNORED_PUBLIC_SUFFIX.include?(r.value) }

--- a/lib/rails_values/public_domain_suffix.rb
+++ b/lib/rails_values/public_domain_suffix.rb
@@ -1,6 +1,6 @@
 require 'public_suffix'
 require 'multi_json'
-
+require_relative 'nexl_public_suffix_list'
 require_relative 'whole_value_concern'
 require_relative 'exceptional_value'
 require_relative 'public_domain_suffix_blank'
@@ -24,7 +24,7 @@ module RailsValues
       @content = if @tld_exception
                    PublicSuffix::Domain.new(content, nil, nil)
                  else
-                   PublicSuffix.parse(content).freeze
+                   PublicSuffix.parse(content, list: NEXL_LIST).freeze
                  end
 
       freeze

--- a/rails_values.gemspec
+++ b/rails_values.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rails_values'
-  spec.version       = '1.6.0'
+  spec.version       = '1.6.1'
   spec.authors       = ['grant']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/rails_values/public_domain_suffix_spec.rb
+++ b/spec/rails_values/public_domain_suffix_spec.rb
@@ -37,6 +37,13 @@ module RailsValues
       expect(value.trd).to be_nil
     end
 
+    it 'can be used for state domains' do
+      value = cast('health.qld.gov.au')
+      expect(value).not_to be_exceptional
+      expect(value.to_s).to eq('health.qld.gov.au')
+      expect(value.trd).to eq('health')
+    end
+
     it 'accepts longer root domain' do
       value = cast('test.americanexpress')
       expect(value.to_s).to eq('test.americanexpress')


### PR DESCRIPTION
This PR will fix the issue where health.qld.gov.au is not seen as a subdomain