### PR TITLE
Exposes address to instance of DisplayNameAddress

### DIFF
--- a/lib/rails_values/display_name_email_address.rb
+++ b/lib/rails_values/display_name_email_address.rb
@@ -5,7 +5,7 @@ module RailsValues
     include Comparable
     include WholeValueConcern
 
-    delegate :format, to: :mail_address
+    delegate :format, :address, to: :mail_address
 
     def to_s
       if mail_address.display_name

--- a/rails_values.gemspec
+++ b/rails_values.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rails_values'
-  spec.version       = '1.6.5'
+  spec.version       = '1.6.6'
   spec.authors       = ['grant']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/rails_values/display_name_email_address_spec.rb
+++ b/spec/rails_values/display_name_email_address_spec.rb
@@ -133,6 +133,10 @@ module RailsValues
       expect(cast('Display Name <sender@nexl.io>').format).to eq('Display Name <sender@nexl.io>')
     end
 
+    it 'can return the just the address' do
+      expect(cast('Display Name <sender@nexl.io>').address).to eq('sender@nexl.io')
+    end
+
     describe '#free_email?' do
       it { expect(cast('My@mail.com')).to be_free_email }
       it { expect(cast('person.email@telstra.com')).not_to be_free_email }


### PR DESCRIPTION
As part of an incoming PR for NEXL 360, we need to expose the address component of a DisplayNameEmailAddress for use in creating TenantContacts