### PR TITLE
[CS-1425] Validate email format using URI::MailTo::EMAIL_REGEXP

### DIFF
--- a/lib/rails_values/email_address.rb
+++ b/lib/rails_values/email_address.rb
@@ -30,7 +30,10 @@ module RailsValues
     delegate :hash, to: :to_s
 
     def exceptional?
-      (present? && domain.blank?) || subdomain.exceptional? || domain.exceptional?
+      (present? && !mail_address.address&.match?(URI::MailTo::EMAIL_REGEXP)) ||
+        (present? && domain.blank?) ||
+        subdomain.exceptional? ||
+        domain.exceptional?
     end
 
     def exceptional_errors(errors, attribute, _options = nil)

--- a/rails_values.gemspec
+++ b/rails_values.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rails_values'
-  spec.version       = '2.0.6'
+  spec.version       = '2.0.7'
   spec.authors       = ['grant']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/rails_values/email_address_spec.rb
+++ b/spec/rails_values/email_address_spec.rb
@@ -90,6 +90,13 @@ module RailsValues
       expect(value).not_to be_free_email
     end
 
+    it 'returns exceptional if () as part of username' do
+      value = cast('john(comment)@nexl.com')
+      expect(value.to_s).to eq('john(comment)@nexl.com')
+      expect(value).not_to be_blank
+      expect(value).to be_exceptional
+    end
+
     it 'returns exceptional if domain with double ..' do
       value = cast('saljubis01@yahoo.com..my')
       expect(value.to_s).to eq('saljubis01@yahoo.com..my')
@@ -135,6 +142,15 @@ module RailsValues
       expect(value).not_to be_blank
       expect(value.domain).to be_regular
       expect(value.domain.to_s).to eq('quoted.com')
+    end
+
+    it 'returns regular email with display name in angle brackets' do
+      value = cast('John Doe <john@example.com>')
+      expect(value.to_s).to eq('john@example.com')
+      expect(value).not_to be_blank
+      expect(value).not_to be_exceptional
+      expect(value.display_name).to eq('John Doe')
+      expect(value.local).to eq('john')
     end
 
     describe '#free_email?' do

--- a/spec/rails_values/email_address_spec.rb
+++ b/spec/rails_values/email_address_spec.rb
@@ -91,8 +91,8 @@ module RailsValues
     end
 
     it 'returns exceptional if () as part of username' do
-      value = cast('john(comment)@nexl.com')
-      expect(value.to_s).to eq('john(comment)@nexl.com')
+      value = cast('john (comment)@nexl.com')
+      expect(value.to_s).to eq('john (comment)@nexl.com')
       expect(value).not_to be_blank
       expect(value).to be_exceptional
     end


### PR DESCRIPTION
Add URI::MailTo::EMAIL_REGEXP validation to the exceptional? method to catch invalid email formats early, preventing Mail::Address from mangling emails with unquoted comments or spaces in the local part.

- Emails like 'John (comment)@example.com' are now marked exceptional
- Properly quoted display names like 'John Doe <John @example.com>' still work
- Database no longer receives corrupted email addresses


Ticket: https://nex-level.atlassian.net/browse/CS-1425


The issue:

<img width="1222" height="558" alt="Screenshot 2026-01-24 at 12 44 01 AM" src="https://github.com/user-attachments/assets/df1c40f0-ffc5-4901-b938-acbd1efbba1f" />
