### PR TITLE
[CS-1367] Add hotmail.ca to personal email domains

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+<!-- Brief description of the changes -->
+
+## Checklist
+- [ ] Changelog updated
+- [ ] Version bumped in `rails_values.gemspec`
+
+## Test plan
+<!-- How was this tested? -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Added `hotmail.ca` to the list of recognized personal email domains.
 
+## [2.0.7] - 2026-01-27
+
+### Changed
+
+- Add `URI::MailTo::EMAIL_REGEXP` validation to catch invalid email formats early, preventing `Mail::Address` from mangling emails with unquoted comments or spaces in the local part. Emails like `John (comment)@example.com` are now marked exceptional.
+
 ## [2.0.6] - 2026-01-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.8] - 2026-01-30
+
+### Added
+
+- Added `hotmail.ca` to the list of recognized personal email domains.
+
 ## [2.0.6] - 2026-01-23
 
 ### Changed

--- a/lib/rails_values/free_email_provider_domains.txt
+++ b/lib/rails_values/free_email_provider_domains.txt
@@ -1049,6 +1049,7 @@ hotepmail.com
 hotfire.net
 hotletter.com
 hotmail.be
+hotmail.ca
 hotmail.co
 hotmail.co.il
 hotmail.com

--- a/rails_values.gemspec
+++ b/rails_values.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rails_values'
-  spec.version       = '2.0.7'
+  spec.version       = '2.0.8'
   spec.authors       = ['grant']
   spec.email         = ['grant@nexl.io']
 

--- a/spec/rails_values/email_address_spec.rb
+++ b/spec/rails_values/email_address_spec.rb
@@ -155,6 +155,7 @@ module RailsValues
 
     describe '#free_email?' do
       it { expect(cast('My@mail.com')).to be_free_email }
+      it { expect(cast('test@hotmail.ca')).to be_free_email }
       it { expect(cast('person.email@telstra.com')).not_to be_free_email }
       it { expect(cast('person@rogers.com')).to be_free_email }
       it { expect(cast('person@sub.rogers.com')).not_to be_free_email }


### PR DESCRIPTION
 ## Summary

  - Added `hotmail.ca` to the list of recognized personal email domains (requested by Fasken)
  - Added missing changelog entry for v2.0.7
  - Bumped version to 2.0.8

 ## Checklist
  - [x] Changelog updated
  - [x] Version bumped in `rails_values.gemspec`

  ## Test plan

  - [x] Added test for `hotmail.ca` being recognized as a personal email domain
  - [x] All existing tests pass